### PR TITLE
Add simple gql_str macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,13 @@ uuid = "09d831e3-9c21-47a9-bfd8-076871817219"
 version = "0.7.3"
 
 [deps]
+GraphQLParser = "0ae10fbf-af58-4883-b66b-ff0ac82d20dd"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
+GraphQLParser = "0.1.1"
 HTTP = "0.8.17, 0.9"
 JSON3 = "1.1.2"
 StructTypes = "1.5"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This package is intended to make connecting to and communicating with GraphQL se
 ## Key Features
 
 - **Querying**, **mutating** and **subscribing** without manual writing of query strings
+- `@gql_str` non-standard string literal which which **validates a query string at compile time** 
 - Deserializing responses directly using **StructTypes**
 - Type stable querying
 - **Construction of Julia types** from GraphQL objects
@@ -74,7 +75,7 @@ response.data["countries"]
 #  Dict{String, Any}("name" => "Australia")
 ```
 
-Or we can query with the query string directly using either a normal `String` or the `gql` [non-standard string literal](https://docs.julialang.org/en/v1/manual/strings/#non-standard-string-literals):
+Or we can query with the query string directly using either a normal `String` or the `gql` [non-standard string literal](https://docs.julialang.org/en/v1/manual/strings/#non-standard-string-literals) which also performs some validation of the string:
 
 ```julia
 query_string = gql"""

--- a/README.md
+++ b/README.md
@@ -74,17 +74,17 @@ response.data["countries"]
 #  Dict{String, Any}("name" => "Australia")
 ```
 
-Or we can query with the query string directly
+Or we can query with the query string directly using either a normal `String` or the `gql` [non-standard string literal](https://docs.julialang.org/en/v1/manual/strings/#non-standard-string-literals):
 
 ```julia
-query_string = """
+query_string = gql"""
     query(
-      \$eq: String
+      $eq: String
     ){
     countries(
         filter:{
             code:{
-                eq:\$eq
+                eq:$eq
             }
         }
     ){

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,6 +9,7 @@ What is GraphQL? It is a *"query language for APIs and a runtime for fulfilling 
 ## Key Features of GraphQLClient
 
 - **Querying**, **mutating** and **subscribing** without manual writing of query strings
+- `@gql_str` non-standard string literal which **validates a query string at compile time**
 - Deserializing responses directly using **StructTypes**
 - Type stable querying
 - **Construction of Julia types** from GraphQL objects
@@ -66,12 +67,33 @@ DocTestSetup = quote
 end
 ```
 
-Now we have a `Client` object, we can query it without having to type a full
-GraphQL query by hand (note, you should be able to test these queries for yourself,
-thanks to [https://github.com/trevorblades/countries](https://github.com/trevorblades/countries)).
-
 !!! info "Using the global `Client`"
     In these examples, if the `client` argument is omitted, the global client will be used instead.
+
+Now we have a `Client` object, we can query it with just a string
+
+```jldoctest
+julia> response = GraphQLClient.execute("{countries{name}}")
+GraphQLClient.GQLResponse{Any}
+  data: Dict{String, Any}
+          countries: Vector{Any}
+```
+
+Or we can use the [`@gql_str`](@ref) macro to perform some validation on the string first (at compile time)
+
+```jldoctest
+julia> str = gql"{countries{name}}"
+"{countries{name}}"
+
+julia> response = GraphQLClient.execute(str)
+GraphQLClient.GQLResponse{Any}
+  data: Dict{String, Any}
+          countries: Vector{Any}
+```
+
+Or we can query without having to type a full GraphQL query by hand at all!
+(Note, you should be able to test these queries for yourself, thanks to [https://github.com/trevorblades/countries](https://github.com/trevorblades/countries)).
+
 
 ```julia-repl
 julia> response = query(client, "countries")

--- a/docs/src/low_level_execution.md
+++ b/docs/src/low_level_execution.md
@@ -94,5 +94,19 @@ julia> str = gql"query($code: ID!){country(code:$code){name}}"
 "query(\$code: ID!){country(code:\$code){name}}"
 ```
 
-In future this will perform some validation on the string, but currently the main advantage of using this is it removes the need to escape `$` characters, as in the example above.
-In future this will perform some validation on the string, but currently the main advantage of using this is it removes the need to escape `$` characters, as in the example above.
+By default this performs some validation on the string, as per [GraphQLParser.jl](https://github.com/mmiller-max/GraphQLParser.jl).
+Validation errors can be turned off by using the second argument to the macro.
+
+```julia-repl
+julia> str = gql"query($code: ID!, $code: ID!){country(code:$code){name}}"
+ERROR: LoadError: Validation Failed
+
+GraphQLParser.RepeatedVariableDefinition
+      message: There can only be one variable named "code".
+     location: Line 1 Column 6
+
+# Use second argument to turn off error (requires full macro form and escaping of $s)
+julia> str = @gql_str "query(\$code: ID!, \$code: ID!){country(code:\$code){name}}" false
+"query(\$code: ID!, \$code: ID!){country(code:\$code){name}}"
+```
+```

--- a/docs/src/low_level_execution.md
+++ b/docs/src/low_level_execution.md
@@ -84,3 +84,15 @@ GraphQLClient.GQLResponse{Any}
   data: Dict{String, Any}
           countries: Vector{Any}
 ```
+
+## `gql` non-standard string literal
+
+GraphQLClient provides the [`@gql_str`](@ref) macro which can be used to generate query strings by prepending a `String` with `gql`.
+
+```julia-repl
+julia> str = gql"query($code: ID!){country(code:$code){name}}"
+"query(\$code: ID!){country(code:\$code){name}}"
+```
+
+In future this will perform some validation on the string, but currently the main advantage of using this is it removes the need to escape `$` characters, as in the example above.
+In future this will perform some validation on the string, but currently the main advantage of using this is it removes the need to escape `$` characters, as in the example above.

--- a/docs/src/public.md
+++ b/docs/src/public.md
@@ -27,6 +27,7 @@ GraphQLClient.execute
 GraphQLClient.GQLResponse
 GraphQLClient.GQLEnum
 GraphQLClient.Alias
+@gql_str
 ```
 
 ## Type Introspection

--- a/src/GraphQLClient.jl
+++ b/src/GraphQLClient.jl
@@ -7,7 +7,8 @@ using StructTypes
 export query, mutate, open_subscription, Client, GQLEnum, Alias,
     full_introspection!, get_queries, get_mutations, get_subscriptions,
     introspect_object, get_introspected_type, initialise_introspected_struct,
-    create_introspected_struct, list_all_introspected_objects, global_graphql_client
+    create_introspected_struct, list_all_introspected_objects, global_graphql_client,
+    @gql_str
 
 # Types
 include("client.jl")
@@ -26,5 +27,6 @@ include("queries.jl")
 include("mutations.jl")
 include("subscriptions.jl")
 include("introspection.jl")
+include("gql_string.jl")
 
 end # module

--- a/src/GraphQLClient.jl
+++ b/src/GraphQLClient.jl
@@ -1,5 +1,6 @@
 module GraphQLClient
 
+using GraphQLParser
 using HTTP
 using JSON3
 using StructTypes

--- a/src/gql_string.jl
+++ b/src/gql_string.jl
@@ -1,0 +1,30 @@
+"""
+    @gql_str
+
+Create a GraphQL query string. Currently, the main advantage of using this macro is that dollar signs do not need to be escaped (see example below). However, in the future this macro will perform (some) validation of the string.
+
+# Examples
+```julia-repl
+julia> client = Client("https://countries.trevorblades.com");
+
+julia> str = gql\"""
+query(\$code: ID!){
+    country(
+        code:\$code
+    ){
+        name
+    }
+}
+\""";
+
+julia> variables = Dict("code" => "BR");
+
+julia> GraphQLClient.execute(client, str; variables=variables)
+GraphQLClient.GQLResponse{Any}
+  data: Dict{String, Any}
+          country: Dict{String, Any}
+```
+"""
+macro gql_str(expr)
+    return expr
+end

--- a/src/gql_string.jl
+++ b/src/gql_string.jl
@@ -1,9 +1,20 @@
 """
-    @gql_str
+    @gql_str(document, throw_on_error=true)
 
-Create a GraphQL query string. Currently, the main advantage of using this macro is that dollar signs do not need to be escaped (see example below). However, in the future this macro will perform (some) validation of the string.
+Create and optionally validate a GraphQL query string.
+
+The string is parsed and semi-validated by GraphQLParser.jl.
+Validation that does not need the schema from the server is performed.
+For further information see the GraphQLParser documentation.
+
+Parsing errors will always be thrown, but other validation errors can be turned off using the second argument.
+
+An additional advantage of using this macro is that dollar signs do not need to be escaped (see example below).
 
 # Examples
+
+General usage
+
 ```julia-repl
 julia> client = Client("https://countries.trevorblades.com");
 
@@ -24,7 +35,69 @@ GraphQLClient.GQLResponse{Any}
   data: Dict{String, Any}
           country: Dict{String, Any}
 ```
+
+Parsing error
+
+```julia-repl
+julia> str = gql\"""
+query(code: ID!){  # no \$ before variable name
+    country(
+        code:\$code
+    ){
+        name
+    }
+}
+\""";
+
+# ERROR: LoadError: ArgumentError: invalid GraphQL string at byte position 7 while parsing
+#     Variable name must start with '\$'
+#     query(code: ID!){  # no \$ before 
+#           ^
+```
+
+Validation error
+
+```julia-repl
+julia> str = gql\"""
+{
+    countries{
+        name
+    }
+}
+
+query{  # Can't have another operation when there is an anonymous operation
+    countries{
+        name
+    }
+}
+\""";
+# ERROR: LoadError: Validation Failed
+
+# GraphQLParser.AnonymousOperationNotAlone
+#       message: This anonymous operation must be the only defined operation.
+#      location: Line 1 Column 1
+```
+
+Turning validation off
+
+```julia-repl
+julia> str = @gql_str \"""
+{
+    countries{
+        name
+    }
+}
+
+query{  # Can't have another operation when there is an anonymous operation
+    countries{
+        name
+    }
+}
+\""" false
+# No error
+```
 """
-macro gql_str(expr)
-    return expr
+macro gql_str(document, throw_on_error=true)
+    is_valid_executable_document(document; throw_on_error)
+    return document
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+GraphQLParser = "0ae10fbf-af58-4883-b66b-ff0ac82d20dd"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"

--- a/test/gql_string.jl
+++ b/test/gql_string.jl
@@ -1,0 +1,2 @@
+# Test escaping of $
+@test "\$" == gql"$"

--- a/test/gql_string.jl
+++ b/test/gql_string.jl
@@ -1,2 +1,9 @@
 # Test escaping of $
-@test "\$" == gql"$"
+@test "query(\$var:ID!){country(var:\$var){name}}" == gql"query($var:ID!){country(var:$var){name}}"
+
+# Test turning off validation errors
+str = @gql_str """
+{countries{name}}
+query{countries{name}}
+""" false
+@test_throws GraphQLParser.ValidationException GraphQLParser.is_valid_executable_document(str; throw_on_error=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using GraphQLClient
+using GraphQLParser
 using HTTP
 using JSON3
 using StructTypes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,4 +17,5 @@ include("utils.jl")
     @testset "Subscriptions" begin include("subscriptions.jl") end
     @testset "HTTP Execution" begin include("http_execution.jl") end
     @testset "Type Construction" begin include("type_construction.jl") end
+    @testset "GQL String" begin include("gql_string.jl") end
 end


### PR DESCRIPTION
An initial simple `@gql_str` macro. This means it can be used and syntax highlighting setup. String validation can follow as this is quite complicated and a big task in its own right.

Closes #6 