### PR TITLE
Handle case where operationName is not provided

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphQLClient"
 uuid = "09d831e3-9c21-47a9-bfd8-076871817219"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 GraphQLParser = "0ae10fbf-af58-4883-b66b-ff0ac82d20dd"

--- a/src/http_execution.jl
+++ b/src/http_execution.jl
@@ -65,16 +65,21 @@ julia> query_string = \"\"\"
 julia> GraphQLClient.execute(client, query_string, operation_name="getCountries")
 ```
 """
+
+function CleanDict(pairs::Pair...)
+    return Dict(p for p in pairs if !isnothing(p[2]))
+end
+
 execute(query::AbstractString, output_type::Type{T}=Any; kwargs...) where T = execute(global_graphql_client(), query, output_type; kwargs...)
-function execute(client::Client, query::AbstractString, output_type::Type{T}=Any; variables=Dict(), operation_name="", kwargs...) where T
-    return execute(client, Dict("query" => query, "variables" => variables, "operationName" => operation_name), output_type; kwargs...)
+function execute(client::Client, query::AbstractString, output_type::Type{T}=Any; variables=Dict(), operation_name=nothing, kwargs...) where T
+    return execute(client, CleanDict("query" => query, "variables" => variables, "operationName" => operation_name), output_type; kwargs...)
 end
 execute(payload::AbstractDict, output_type::Type{T}=Any; kwargs...) where T  = execute(global_graphql_client(), payload, output_type; kwargs...)
 function execute(client::Client, payload::AbstractDict, output_type::Type{T}=Any; kwargs...) where T
     return execute(client.endpoint, payload, client.headers, output_type; kwargs...)
 end
-function execute(endpoint::AbstractString, query::AbstractString, headers::AbstractDict=Dict(), output_type::Type{T}=Any; variables=Dict(), operation_name="", kwargs...) where T
-    return execute(endpoint, Dict("query" => query, "variables" => variables, "operationName" => operation_name), headers, output_type; kwargs...)
+function execute(endpoint::AbstractString, query::AbstractString, headers::AbstractDict=Dict(), output_type::Type{T}=Any; variables=Dict(), operation_name=nothing, kwargs...) where T
+    return execute(endpoint, CleanDict("query" => query, "variables" => variables, "operationName" => operation_name), headers, output_type; kwargs...)
 end
 function execute(endpoint::AbstractString, payload::AbstractDict, headers::AbstractDict=Dict(), output_type::Type{T}=Any; kwargs...) where T
     return _execute(endpoint, JSON3.write(payload), headers, output_type; kwargs...)


### PR DESCRIPTION
Solves #14 
Providing empty `operationName` breaks some servers. Restores behaviour to 0.7.2 for the case when operation name is not provided.